### PR TITLE
* lisp/xwidget.el (report-xwidget-bug): Add a function to submit a bug

### DIFF
--- a/README.xwidget
+++ b/README.xwidget
@@ -95,16 +95,10 @@ until Emacs 25. OTOH since I now use xwidget emacs as my primary
 emacs, I will merge from trunk much more often than in the past.
 
 ** reporting bugs
-emacs xwidgets uses the same tracker as mainline emacs, but a
-different package.
+Emacs xwidgets uses the same tracker as mainline emacs, but a
+different package. To report a bug:
+M-x report-xwidget-bug
 
-m-x report-emacs-bug
-
-Change the address to:
-submit@debbugs.gnu.org
-
-Include this line first in the body:
-Package: emacs-xwidgets
 
 browse bugs:
 http://debbugs.gnu.org/cgi/pkgreport.cgi?package=emacs-xwidgets

--- a/lisp/xwidget.el
+++ b/lisp/xwidget.el
@@ -12,6 +12,7 @@
 ;;; Code:
 
 (eval-when-compile (require 'cl))
+(require 'reporter)
 
 (defun xwidget-insert (pos type title width height)
   "Insert an xwidget at POS, given ID, TYPE, TITLE WIDTH and
@@ -466,6 +467,26 @@ yet, so deinstall Flash instead for now."
     (setq xwidget-webkit-kill-flash-oneshot t)))
 
 (xwidget-webkit-kill-flash)
+
+(defun report-xwidget-bug ()
+  "Report a bug in GNU Emacs about the XWidget branch.
+Prompts for bug subject.  Leaves you in a mail buffer."
+  (interactive)
+  (let ((reporter-prompt-for-summary-p t))
+    (reporter-submit-bug-report "submit@debbugs.gnu.org" nil nil nil nil
+                                (format "Package: emacs-xwidgets
+
+Please describee xactly whata ctions triggered the bug, and the
+precise symptoms of the bug.  If you can, give a recipe starting
+from `emacs -Q'.
+
+If Emacs crashed, and you have the Emacs process in the gdb
+deubbger, please include the output from the following gdb
+commands:
+    `bt full' and `xbacktrace'.
+
+For information about debugging Emacs, please read the file
+%s" (expand-file-name "DEBUG" data-directory)))))
 
 (provide 'xwidget)
 


### PR DESCRIPTION
with the proper address and pseudo-header.
- README.xwidget: Update the documentation to mention
  `report-xwidget-bug'.
