### PR TITLE
* src/xwidget.c (xwidget_init_view): Prevent an error while displaying a

### DIFF
--- a/lisp/xwidget.el
+++ b/lisp/xwidget.el
@@ -458,6 +458,7 @@ It can be retrieved with `(xwidget-get XWIDGET PROPNAME)'."
   "Ask beforek illing a buffer that has xwidgets."
   (let ((xwidgets (get-buffer-xwidgets (current-buffer))))
     (or (not xwidgets)
+        (not (memq t (mapcar 'xwidget-query-on-exit-flag xwidgets)))
         (yes-or-no-p
          (format "Buffer %S has xwidgets; kill it? "
                  (buffer-name (current-buffer)))))))

--- a/lisp/xwidget.el
+++ b/lisp/xwidget.el
@@ -438,16 +438,24 @@ It can be retrieved with `(xwidget-get XWIDGET PROPNAME)'."
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun xwidget-delete-zombies ()
+  (mapcar (lambda (xwidget-view)
+            (when (or (not (window-live-p (xwidget-view-window xwidget-view)))
+                      (not (find (xwidget-view-model xwidget-view)
+                                 xwidget-list)))
+              (delete-xwidget-view xwidget-view)))
+          xwidget-view-list))
+
 (defun xwidget-cleanup ()
   "Delete zombie xwidgets."
   ;;its still pretty easy to trigger bugs with xwidgets.
   ;;this function tries to implement a workaround
   (interactive)
-  (xwidget-delete-zombies) ;;kill xviews who should have been deleted but stull linger
-  (redraw-display);;redraw display otherwise ghost of zombies  will remain to haunt the screen
-  )
-
-
+  ;; kill xviews who should have been deleted but stull linger
+  (xwidget-delete-zombies)
+  ;; redraw display otherwise ghost of zombies  will remain to haunt the screen
+  (redraw-display))
 
 ;;this is a workaround because I cant find the right place to put it in C
 ;;seems to work well in practice though

--- a/src/print.c
+++ b/src/print.c
@@ -1771,6 +1771,11 @@ print_object (Lisp_Object obj, Lisp_Object printcharfun, bool escapeflag)
 	  strout ("#<xwidget ", -1, -1, printcharfun);
 	  PRINTCHAR ('>');
 	}
+      else if (XXWIDGET_VIEW_P (obj))
+	{
+	  strout ("#<xwidget-view ", -1, -1, printcharfun);
+	  PRINTCHAR ('>');
+	}
 #endif      
       else if (WINDOWP (obj))
 	{

--- a/src/print.c
+++ b/src/print.c
@@ -1766,12 +1766,12 @@ print_object (Lisp_Object obj, Lisp_Object printcharfun, bool escapeflag)
 	  PRINTCHAR ('>');
 	}
 #ifdef HAVE_XWIDGETS
-      else if (XXWIDGETP (obj))
+      else if (XWIDGETP (obj))
 	{
 	  strout ("#<xwidget ", -1, -1, printcharfun);
 	  PRINTCHAR ('>');
 	}
-      else if (XXWIDGET_VIEW_P (obj))
+      else if (XWIDGET_VIEW_P (obj))
 	{
 	  strout ("#<xwidget-view ", -1, -1, printcharfun);
 	  PRINTCHAR ('>');

--- a/src/xdisp.c
+++ b/src/xdisp.c
@@ -5051,7 +5051,7 @@ handle_single_display_spec (struct it *it, Lisp_Object spec, Lisp_Object object,
 #endif /* not HAVE_WINDOW_SYSTEM */
              || (CONSP (value) && EQ (XCAR (value), Qspace))
 #ifdef HAVE_XWIDGETS
-             || XWIDGETP(value)
+             || valid_xwidget_spec_p(value)
 #endif
              );
 
@@ -5129,7 +5129,7 @@ handle_single_display_spec (struct it *it, Lisp_Object spec, Lisp_Object object,
 	  retval = 1 + (it->area == TEXT_AREA);
 	}
 #ifdef HAVE_XWIDGETS
-      else if (XWIDGETP(value))
+      else if (valid_xwidget_spec_p(value))
 	{
           //printf("handle_single_display_spec: im an xwidget!!\n");
           it->what = IT_XWIDGET;
@@ -22879,7 +22879,7 @@ calc_pixel_width_or_height (double *res, struct it *it, Lisp_Object prop,
 	      return OK_PIXELS (width_p ? img->width : img->height);
 	    }
 #ifdef HAVE_XWIDGETS
-	  if (FRAME_WINDOW_P (it->f) && valid_xwidget_p (prop))
+	  if (FRAME_WINDOW_P (it->f) && valid_xwidget_spec_p (prop))
 	    {
               printf("calc_pixel_width_or_height: return dummy size FIXME\n");
               return OK_PIXELS (width_p ? 100 : 100);

--- a/src/xwidget.c
+++ b/src/xwidget.c
@@ -1883,12 +1883,21 @@ xwidget_end_redisplay (struct window *w, struct glyph_matrix *matrix)
 void
 kill_buffer_xwidgets (Lisp_Object buffer)
 {
-  Lisp_Object tail, xw;
+  Lisp_Object tail, xwidget;
   for (tail = Fget_buffer_xwidgets (buffer); CONSP (tail); tail = XCDR (tail))
     {
-      xw = XCAR (tail);
-      Vxwidget_list = Fdelq (xw, Vxwidget_list);
+      xwidget = XCAR (tail);
+      Vxwidget_list = Fdelq (xwidget, Vxwidget_list);
       /* TODO free the GTK things in xw */
+      {
+        CHECK_XWIDGET (xwidget);
+        struct xwidget *xw = XXWIDGET (xwidget);
+        if (xw->widget_osr && xw->widgetwindow_osr)
+          {
+            gtk_widget_destroy(GTK_WIDGET (xw->widget_osr));
+            gtk_widget_destroy(GTK_WIDGET (xw->widgetwindow_osr));
+          }
+      }
     }
 }
 

--- a/src/xwidget.c
+++ b/src/xwidget.c
@@ -1437,6 +1437,24 @@ DEFUN ("xwidget-view-info", Fxwidget_view_info , Sxwidget_view_info, 1, 1, 0, do
   return info;
 }
 
+DEFUN ("xwidget-view-model", Fxwidget_view_model, Sxwidget_view_model,
+       1, 1, 0,
+       doc: /* get xwidget view model */)
+  (Lisp_Object xwidget_view)
+{
+  CHECK_XWIDGET_VIEW (xwidget_view);
+  return XXWIDGET_VIEW (xwidget_view)->model;
+}
+
+DEFUN ("xwidget-view-window", Fxwidget_view_window, Sxwidget_view_window,
+       1, 1, 0,
+       doc: /* get xwidget view window */)
+  (Lisp_Object xwidget_view)
+{
+  CHECK_XWIDGET_VIEW (xwidget_view);
+  return XXWIDGET_VIEW (xwidget_view)->w;
+}
+
 DEFUN ("xwidget-send-keyboard-event", Fxwidget_send_keyboard_event, Sxwidget_send_keyboard_event, 2, 2, 0, doc:/* synthesize a kbd event for a xwidget. */
        )
   (Lisp_Object  xwidget, Lisp_Object keydescriptor)
@@ -1572,6 +1590,8 @@ syms_of_xwidget (void)
   defsubr (&Sxwidget_view_info);
   defsubr (&Sxwidget_resize);
   defsubr (&Sget_buffer_xwidgets);
+  defsubr (&Sxwidget_view_model);
+  defsubr (&Sxwidget_view_window);
 
 #ifdef HAVE_WEBKIT_OSR
   defsubr (&Sxwidget_webkit_goto_uri);

--- a/src/xwidget.c
+++ b/src/xwidget.c
@@ -1520,30 +1520,15 @@ DEFUN ("xwidget-send-keyboard-event", Fxwidget_send_keyboard_event, Sxwidget_sen
   return Qnil;
 }
 
-
-
-DEFUN("xwidget-delete-zombies", Fxwidget_delete_zombies , Sxwidget_delete_zombies, 0,0,0, doc: /* */)
-  (void)
+DEFUN ("delete-xwidget-view", Fdelete_xwidget_view, Sdelete_xwidget_view,
+       1, 1, 0,
+       doc: /* Delete the XWIDGET-VIEW. */)
+  (Lisp_Object xwidget_view)
 {
-  /*
-    - remove all views with window gone
-
-    TODO
-    - remove all xwidgets with buffer gone
-    - remove all views with xw gone
-
-   */
-  struct xwidget_view* xv = NULL;
-  for (Lisp_Object tail = Vxwidget_view_list; CONSP (tail); tail = XCDR (tail))
-    {
-      if (XWIDGET_VIEW_P (XCAR (tail))) {
-        xv = XXWIDGET_VIEW (XCAR (tail));
-        if(!WINDOW_LIVE_P (xv->w)) {
-          gtk_widget_destroy(GTK_WIDGET(xv->widgetwindow));
-          Vxwidget_view_list = Fdelq (XCAR (tail), Vxwidget_view_list);
-        }
-      }
-    }
+  CHECK_XWIDGET_VIEW (xwidget_view);
+  struct xwidget_view *xv = XXWIDGET_VIEW (xwidget_view);
+  gtk_widget_destroy(GTK_WIDGET (xv->widgetwindow));
+  Vxwidget_view_list = Fdelq (xwidget_view, Vxwidget_view_list);
 }
 
 DEFUN ("xwidget-view-lookup", Fxwidget_view_lookup, Sxwidget_view_lookup,
@@ -1653,7 +1638,7 @@ syms_of_xwidget (void)
   defsubr (&Sxwgir_xwidget_call_method  );
   defsubr (&Sxwgir_require_namespace);
   defsubr (&Sxwidget_size_request  );
-  defsubr (&Sxwidget_delete_zombies);
+  defsubr (&Sdelete_xwidget_view);
   defsubr (&Sxwidget_disable_plugin_for_mime);
 
   defsubr (&Sxwidget_send_keyboard_event);

--- a/src/xwidget.c
+++ b/src/xwidget.c
@@ -998,6 +998,10 @@ xwidget_init_view (struct xwidget *xww,
     //Cairo view
     //uhm cairo is differentish in gtk 3.
     //gdk_cairo_create (gtk_widget_get_window (FRAME_GTK_WIDGET (s->f)));
+    xv->widget = gtk_drawing_area_new();
+    g_signal_connect (G_OBJECT (    xv->widget), "draw",
+                      G_CALLBACK (xwidget_osr_draw_callback), NULL);
+    
   } else if (EQ(xww->type, Qwebkit_osr)||
              EQ(xww->type, Qsocket_osr)||
              (!NILP (Fget(xww->type, QCxwgir_class))))//xwgir widgets are OSR

--- a/src/xwidget.c
+++ b/src/xwidget.c
@@ -209,7 +209,7 @@ TYPE is a symbol which can take one of the following values:
   
   xw->height = XFASTINT(height);
   xw->width = XFASTINT(width);
-  xw->kill_without_query = 1;
+  xw->kill_without_query = 0;
   XSETXWIDGET (val, xw); // set the vectorlike_header of VAL with the correct value
   Vxwidget_list = Fcons (val, Vxwidget_list);
   xw->widgetwindow_osr = NULL;

--- a/src/xwidget.c
+++ b/src/xwidget.c
@@ -1401,7 +1401,7 @@ DEFUN ("xwidget-view-p", Fxwidget_view_p, Sxwidget_view_p, 1, 1, 0,
   return XWIDGET_VIEW_P (object) ? Qt : Qnil;
 }
 
-DEFUN("xwidget-info", Fxwidget_info , Sxwidget_info, 1,1,0, doc: /* get xwidget props */)
+DEFUN ("xwidget-info", Fxwidget_info , Sxwidget_info, 1,1,0, doc: /* get xwidget props */)
   (Lisp_Object xwidget)
 {
   CHECK_XWIDGET (xwidget);
@@ -1419,7 +1419,7 @@ DEFUN("xwidget-info", Fxwidget_info , Sxwidget_info, 1,1,0, doc: /* get xwidget 
   return info;
 }
 
-DEFUN("xwidget-view-info", Fxwidget_view_info , Sxwidget_view_info, 1, 1, 0, doc: /* get xwidget view props */)
+DEFUN ("xwidget-view-info", Fxwidget_view_info , Sxwidget_view_info, 1, 1, 0, doc: /* get xwidget view props */)
   (Lisp_Object xwidget_view)
 {
   CHECK_XWIDGET_VIEW (xwidget_view);

--- a/src/xwidget.c
+++ b/src/xwidget.c
@@ -209,6 +209,7 @@ TYPE is a symbol which can take one of the following values:
   
   xw->height = XFASTINT(height);
   xw->width = XFASTINT(width);
+  xw->kill_without_query = 1;
   XSETXWIDGET (val, xw); // set the vectorlike_header of VAL with the correct value
   Vxwidget_list = Fcons (val, Vxwidget_list);
   xw->widgetwindow_osr = NULL;
@@ -1598,6 +1599,30 @@ DEFUN ("set-xwidget-plist", Fset_xwidget_plist, Sset_xwidget_plist,
   return plist;
 }
 
+DEFUN ("set-xwidget-query-on-exit-flag",
+       Fset_xwidget_query_on_exit_flag, Sset_xwidget_query_on_exit_flag,
+       2, 2, 0,
+       doc: /* Specify if query is needed for XWIDGET when Emacs is
+exited.  If the second argument FLAG is non-nil, Emacs will query the
+user before exiting or killing a buffer if XWIDGET is running.  This
+function returns FLAG. */)
+  (Lisp_Object xwidget, Lisp_Object flag)
+{
+  CHECK_XWIDGET (xwidget);
+  XXWIDGET (xwidget)->kill_without_query = NILP (flag);
+  return flag;
+}
+
+DEFUN ("xwidget-query-on-exit-flag",
+       Fxwidget_query_on_exit_flag, Sxwidget_query_on_exit_flag,
+       1, 1, 0,
+       doc: /* Return the current value of query-on-exit flag for XWIDGET. */)
+  (Lisp_Object xwidget)
+{
+  CHECK_XWIDGET (xwidget);
+  return (XXWIDGET (xwidget)->kill_without_query ? Qnil : Qt);
+}
+
 void
 syms_of_xwidget (void)
 {
@@ -1615,6 +1640,8 @@ syms_of_xwidget (void)
   defsubr (&Sxwidget_view_model);
   defsubr (&Sxwidget_view_window);
   defsubr (&Sxwidget_view_lookup);
+  defsubr (&Sxwidget_query_on_exit_flag);
+  defsubr (&Sset_xwidget_query_on_exit_flag);
 
 #ifdef HAVE_WEBKIT_OSR
   defsubr (&Sxwidget_webkit_goto_uri);

--- a/src/xwidget.c
+++ b/src/xwidget.c
@@ -1415,7 +1415,7 @@ DEFUN ("xwidget-info", Fxwidget_info , Sxwidget_info, 1,1,0, doc: /* get xwidget
   XSETFASTINT(n, xw->width);
   ASET (info, 2, n);
   XSETFASTINT(n, xw->height);
-  ASET (info, 2, n);
+  ASET (info, 3, n);
 
   return info;
 }

--- a/src/xwidget.h
+++ b/src/xwidget.h
@@ -7,7 +7,7 @@ void syms_of_xwidget ();
 extern Lisp_Object Qxwidget;
 
 
-int valid_xwidget_p (Lisp_Object object) ;
+int valid_xwidget_spec_p (Lisp_Object object) ;
 
 #include <gtk/gtk.h>
 
@@ -64,19 +64,21 @@ struct xwidget_view {
   long handler_id;
 };
 
-
-/* Test for xwidget (xwidget . spec)  (car must be the symbol xwidget)*/
-#define XWIDGETP(x) (CONSP (x) && EQ (XCAR (x), Qxwidget))
-
 /* Test for xwidget pseudovector*/
-#define XXWIDGETP(x) PSEUDOVECTORP (x, PVEC_XWIDGET)
-#define XXWIDGET(a) (eassert (XXWIDGETP(a)), \
+#define XWIDGETP(x) PSEUDOVECTORP (x, PVEC_XWIDGET)
+#define XXWIDGET(a) (eassert (XWIDGETP(a)), \
                      (struct xwidget *) XUNTAG(a, Lisp_Vectorlike))
 
+#define CHECK_XWIDGET(x) \
+  CHECK_TYPE (XWIDGETP (x), Qxwidgetp, x)
+
 /* Test for xwidget_view pseudovector */
-#define XXWIDGET_VIEW_P(x) PSEUDOVECTORP (x, PVEC_XWIDGET_VIEW)
-#define XXWIDGET_VIEW(a) (eassert (XXWIDGET_VIEW_P(a)), \
+#define XWIDGET_VIEW_P(x) PSEUDOVECTORP (x, PVEC_XWIDGET_VIEW)
+#define XXWIDGET_VIEW(a) (eassert (XWIDGET_VIEW_P(a)), \
                           (struct xwidget_view *) XUNTAG(a, Lisp_Vectorlike))
+
+#define CHECK_XWIDGET_VIEW(x) \
+  CHECK_TYPE (XWIDGET_VIEW_P (x), Qxwidget_view_p, x)
 
 struct xwidget_type
 {

--- a/src/xwidget.h
+++ b/src/xwidget.h
@@ -37,10 +37,6 @@ struct xwidget{
   /* Non-nil means kill silently if Emacs is exited. */
   unsigned int kill_without_query : 1;
 
-  //TODO these are WIP
-
-
-  
 };
 
 

--- a/src/xwidget.h
+++ b/src/xwidget.h
@@ -34,6 +34,8 @@ struct xwidget{
   //for offscreen widgets, unused if not osr
   GtkWidget* widget_osr;
   GtkContainer* widgetwindow_osr;
+  /* Non-nil means kill silently if Emacs is exited. */
+  unsigned int kill_without_query : 1;
 
   //TODO these are WIP
 


### PR DESCRIPTION
xwidget of type `cairo' but doesn't do anything useful.
