### PR TITLE
* lisp/xwidget.el (xwidget-delete-zombies): Rewrite with dolist/memq instead of mapcar/find.

### DIFF
--- a/lisp/xwidget.el
+++ b/lisp/xwidget.el
@@ -440,12 +440,11 @@ It can be retrieved with `(xwidget-get XWIDGET PROPNAME)'."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun xwidget-delete-zombies ()
-  (mapcar (lambda (xwidget-view)
-            (when (or (not (window-live-p (xwidget-view-window xwidget-view)))
-                      (not (find (xwidget-view-model xwidget-view)
-                                 xwidget-list)))
-              (delete-xwidget-view xwidget-view)))
-          xwidget-view-list))
+  (dolist (xwidget-view xwidget-view-list)
+    (when (or (not (window-live-p (xwidget-view-window xwidget-view)))
+              (not (memq (xwidget-view-model xwidget-view)
+                         xwidget-list)))
+      (delete-xwidget-view xwidget-view))))
 
 (defun xwidget-cleanup ()
   "Delete zombie xwidgets."


### PR DESCRIPTION
Minor rewrite.
