### PR TITLE
Offscreen forward events

### DIFF
--- a/lisp/xwidget.el
+++ b/lisp/xwidget.el
@@ -440,12 +440,11 @@ It can be retrieved with `(xwidget-get XWIDGET PROPNAME)'."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun xwidget-delete-zombies ()
-  (mapcar (lambda (xwidget-view)
-            (when (or (not (window-live-p (xwidget-view-window xwidget-view)))
-                      (not (find (xwidget-view-model xwidget-view)
-                                 xwidget-list)))
-              (delete-xwidget-view xwidget-view)))
-          xwidget-view-list))
+  (dolist (xwidget-view xwidget-view-list)
+    (when (or (not (window-live-p (xwidget-view-window xwidget-view)))
+              (not (memq (xwidget-view-model xwidget-view)
+                         xwidget-list)))
+      (delete-xwidget-view xwidget-view))))
 
 (defun xwidget-cleanup ()
   "Delete zombie xwidgets."

--- a/src/xwidget.c
+++ b/src/xwidget.c
@@ -987,9 +987,8 @@ xwidget_init_view (struct xwidget *xww,
   } else if (EQ(xww->type, Qwebkit_osr)||
              EQ(xww->type, Qsocket_osr)||
              (!NILP (Fget(xww->type, QCxwgir_class))))//xwgir widgets are OSR
-    {
-#ifdef HAVE_WEBKIT_OSR //TODO the ifdef isnt really relevant anymore, we always have osr
-      printf("osr init:%s\n",SDATA(SYMBOL_NAME(xww->type)));
+  {
+    printf("osr init:%s\n",SDATA(SYMBOL_NAME(xww->type)));
     xv->widget = gtk_drawing_area_new();
     gtk_widget_set_app_paintable ( xv->widget, TRUE); //because expose event handling
     gtk_widget_add_events(xv->widget,
@@ -1021,14 +1020,6 @@ xwidget_init_view (struct xwidget *xww,
                       G_CALLBACK (xwidget_osr_draw_callback), NULL);
 
 
-
-
-    /* g_signal_connect (G_OBJECT (    xv->widget), "key-press-event", */
-    /*                   G_CALLBACK (xwidget_osr_event_forward), NULL); */
-    /* g_signal_connect (G_OBJECT (    xv->widget), "key-release-event", */
-    /*                   G_CALLBACK (xwidget_osr_event_forward), NULL); */
-    
-#endif  /* HAVE_WEBKIT_OSR */
 
 
   } 

--- a/src/xwidget.c
+++ b/src/xwidget.c
@@ -1011,12 +1011,12 @@ xwidget_init_view (struct xwidget *xww,
                         G_CALLBACK (xwidget_osr_event_forward), NULL);
     }else{
       //xwgir debug , orthogonal to forwarding
-      g_signal_connect (G_OBJECT (xv->widget), "motion-notify-event",
+      g_signal_connect (G_OBJECT (xv->widget), "enter-notify-event",
                         G_CALLBACK (xwidget_osr_event_set_embedder), xv);
     }
     
     //draw
-    g_signal_connect (G_OBJECT (    xv->widget), "draw",
+    g_signal_connect (G_OBJECT (xv->widget), "draw",
                       G_CALLBACK (xwidget_osr_draw_callback), NULL);
 
   } 

--- a/src/xwidget.c
+++ b/src/xwidget.c
@@ -275,8 +275,6 @@ TYPE is a symbol which can take one of the following values:
                             "navigation-policy-decision-requested",
                             G_CALLBACK (webkit_osr_navigation_policy_decision_requested_callback),
                             xw);
-          //webkit_web_view_load_uri(WEBKIT_WEB_VIEW(xw->widget_osr), "http://www.fsf.org");
-
       }
 
       if (EQ(xw->type, Qsocket_osr)) {

--- a/src/xwidget.c
+++ b/src/xwidget.c
@@ -233,7 +233,8 @@ TYPE is a symbol which can take one of the following values:
       gtk_widget_set_size_request (GTK_WIDGET (xw->widget_osr), xw->width, xw->height);
       gtk_container_add (GTK_CONTAINER (xw->widgetwindow_osr), xw->widget_osr);
 
-      gtk_widget_show_all (xw->widgetwindow_osr);
+      gtk_widget_show (xw->widget_osr);
+      gtk_widget_show (xw->widgetwindow_osr);
 
       /* store some xwidget data in the gtk widgets for convenient retrieval in the event handlers. */
       g_object_set_data (G_OBJECT (xw->widget_osr), XG_XWIDGET, (gpointer) (xw));

--- a/src/xwidget.c
+++ b/src/xwidget.c
@@ -994,10 +994,7 @@ xwidget_init_view (struct xwidget *xww,
     printf("osr init:%s\n",SDATA(SYMBOL_NAME(xww->type)));
     xv->widget = gtk_drawing_area_new();
     gtk_widget_set_app_paintable ( xv->widget, TRUE); //because expose event handling
-    gtk_widget_add_events(xv->widget,
-                          GDK_BUTTON_PRESS_MASK
-                          | GDK_BUTTON_RELEASE_MASK
-                          | GDK_POINTER_MOTION_MASK);
+    gtk_widget_add_events(xv->widget, GDK_ALL_EVENTS_MASK);
 
     /* Draw the view on damage-event */
     g_signal_connect (G_OBJECT (xww->widgetwindow_osr), "damage-event",

--- a/src/xwidget.h
+++ b/src/xwidget.h
@@ -33,7 +33,7 @@ struct xwidget{
 
   //for offscreen widgets, unused if not osr
   GtkWidget* widget_osr;
-  GtkContainer* widgetwindow_osr;
+  GtkWidget* widgetwindow_osr;
   /* Non-nil means kill silently if Emacs is exited. */
   unsigned int kill_without_query : 1;
 
@@ -53,8 +53,8 @@ struct xwidget_view {
   int hidden;//if the "live" instance isnt drawn
 
   GtkWidget* widget;
-  GtkContainer* widgetwindow;
-  GtkContainer* emacswindow;
+  GtkWidget* widgetwindow;
+  GtkWidget* emacswindow;
   int x; int y;
   int clip_right; int clip_bottom; int clip_top; int clip_left;
 


### PR DESCRIPTION
\o/ It works with both "classic" widget (button) and Webkit.
